### PR TITLE
install/enable/start the nscd service in the cluster_setup role

### DIFF
--- a/ansible/roles/cluster_setup/tasks/main.yml
+++ b/ansible/roles/cluster_setup/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include: nscd.yml
 - include: time.yml
 - include: hosts.yml
 - include: openstack.yml

--- a/ansible/roles/cluster_setup/tasks/nscd.yml
+++ b/ansible/roles/cluster_setup/tasks/nscd.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure nscd packages are installed
+  yum:
+    name: nscd
+    state: present
+
+- name: Ensure nscd is enabled
+  service:
+    name: nscd
+    state: started
+    enabled: yes


### PR DESCRIPTION
we had to apply this workaround in our installation so ssh to VMs is faster

